### PR TITLE
Guzzle7.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
+        "colinodell/psr-testlogger": "^1.2",
         "phpstan/phpstan": "~0.12.32",
         "phpstan/phpstan-phpunit": "^0.12.11",
         "phpstan/phpstan-strict-rules": "^0.12.2",

--- a/src/LogMiddleware.php
+++ b/src/LogMiddleware.php
@@ -112,11 +112,11 @@ final class LogMiddleware
         return function (\Exception $reason) use ($request, $options) {
             if ($reason instanceof RequestException && $reason->hasResponse() === true) {
                 $this->handler->log($this->logger, $request, $reason->getResponse(), $reason, $this->stats, $options);
-                return \GuzzleHttp\Promise\rejection_for($reason);
+                return new \GuzzleHttp\Promise\RejectedPromise($reason);
             }
 
             $this->handler->log($this->logger, $request, null, $reason, $this->stats, $options);
-            return \GuzzleHttp\Promise\rejection_for($reason);
+            return new \GuzzleHttp\Promise\RejectedPromise($reason);
         };
     }
 

--- a/src/LogMiddleware.php
+++ b/src/LogMiddleware.php
@@ -112,11 +112,11 @@ final class LogMiddleware
         return function (\Exception $reason) use ($request, $options) {
             if ($reason instanceof RequestException && $reason->hasResponse() === true) {
                 $this->handler->log($this->logger, $request, $reason->getResponse(), $reason, $this->stats, $options);
-                return new \GuzzleHttp\Promise\RejectedPromise($reason);
+                return \GuzzleHttp\Promise\Create::rejectionFor($reason);
             }
 
             $this->handler->log($this->logger, $request, null, $reason, $this->stats, $options);
-            return new \GuzzleHttp\Promise\RejectedPromise($reason);
+            return \GuzzleHttp\Promise\Create::rejectionFor($reason);
         };
     }
 

--- a/tests/AbstractLoggerMiddlewareTest.php
+++ b/tests/AbstractLoggerMiddlewareTest.php
@@ -15,7 +15,7 @@ use GuzzleLogMiddleware\LogMiddleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Log\Test\TestLogger;
+use ColinODell\PsrTestLogger\TestLogger;
 
 abstract class AbstractLoggerMiddlewareTest extends TestCase
 {


### PR DESCRIPTION
### Description

This is a proposal to fix the incompatibility with newer Guzzle versions from 7.7 and Guzzle\Promises from 2.0, as described in this issue:
https://github.com/gmponos/guzzle-log-middleware/issues/48

### Changes

To fix "Call to undefined function" error:
* Replace calls to removed function \GuzzleHttp\Promise\rejection_for() with equivalent \GuzzleHttp\Promise\Create::rejectionFor()

To fix failing testsuite:
* Add package colinodell/psr-testlogger as a development dependency
* Replace references to removed class Psr\Log\Test\TestLogger with equivalent ColinODell\PsrTestLogger\TestLogger